### PR TITLE
Improve regex parsing in Github hook

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -27,7 +27,8 @@ jobs:
       run: |
           links=()
           for f in ${{ steps.changes.outputs.md }}; do
-            links+=($(cat $f | grep discussion | awk -F" " '{print $2}'))
+            echo "Checking file: ${f}"
+            links+=($(cat $f | grep "discussion: https://github.com/.*/[0-9+]" | awk -F" " '{print $2}'))
           done
           curl -X POST $URL \
             -H "Content-Type: application/json" \

--- a/rfc/0000/README.md
+++ b/rfc/0000/README.md
@@ -6,7 +6,7 @@ discussion: https://github.com/prashanthb-ai/rfc/issues/7
 
 # RFC 0: Test Metadata Parsing
 
-This RFC serves as a test for simple metadata parsing through a GitHub action.
+This RFC serves as a test for simple metadata parsing through a GitHub action
 
 ## Appendix
 


### PR DESCRIPTION
Discussion issues parsing was using a regex that was too broad. Scoped
to only github issue looking links.